### PR TITLE
Add SessionStart hook to auto-install skills and dependencies

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install Python dependencies
+pip install -q scipy || true
+
+# Copy skills from repo into Claude's skill discovery directory
+if [ -d "$CLAUDE_PROJECT_DIR/skills" ]; then
+  for skill_dir in "$CLAUDE_PROJECT_DIR/skills"/*/; do
+    skill_name=$(basename "$skill_dir")
+    mkdir -p "$HOME/.claude/skills/$skill_name"
+    cp "$skill_dir/SKILL.md" "$HOME/.claude/skills/$skill_name/SKILL.md" 2>/dev/null || true
+  done
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Copies skills from repo's skills/ directory into ~/.claude/skills/
and installs scipy on session start, so /iv-enhanced works without
manual setup each session.

https://claude.ai/code/session_01YQtZiPQ17JnQFqkgGH9HFv